### PR TITLE
add describe_add_route decorator

### DIFF
--- a/sanic_transmute/route.py
+++ b/sanic_transmute/route.py
@@ -23,3 +23,34 @@ def _convert_to_sanic_path(path):
     convert based on route syntax.
     """
     return path.replace("{", "<").replace("}", ">")
+
+
+def describe_add_route(app_or_blueprint, **kwargs):
+    """
+    Decorator to describe a route and add in a blueprint or app
+
+    Ex:
+        bp = Blueprint('myapi', url_prefix="/api/v1")
+
+        @describe_add_route(bp, paths="/myendpoint", methods="GET")
+        async def medias_series() -> MyReturnType:
+            res = ...
+            return res
+
+    """
+    # if we have a single method, make it a list.
+    if isinstance(kwargs.get("paths"), string_type):
+        kwargs["paths"] = [kwargs["paths"]]
+    if isinstance(kwargs.get("methods"), string_type):
+        kwargs["methods"] = [kwargs["methods"]]
+    attrs = TransmuteAttributes(**kwargs)
+
+    def decorator(fnc):
+        if hasattr(fnc, "transmute"):
+            fnc.transmute = fnc.transmute | attrs
+        else:
+            fnc.transmute = attrs
+        add_route(app_or_blueprint, fnc)
+        return fnc
+
+    return decorator


### PR DESCRIPTION
Allow something like:

        bp = Blueprint('myapi', url_prefix="/api/v1")

        @describe_add_route(bp, paths="/myendpoint", methods="GET")
        async def medias_series() -> MyReturnType:
            res = ...
            return res